### PR TITLE
Fixed a bug that would return unfinished CSRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,11 @@ language: swift
 script:
 - set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/CertificateSigningRequest.xcworkspace -scheme CertificateSigningRequest-Example -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.3' ONLY_ACTIVE_ARCH=NO | xcpretty
 - pod lib lint
+deploy:
+  provider: script
+  script:
+  - source ~/.rvm/scripts/rvm
+  - rvm use default
+  - pod trunk push
+  on:
+    tags: true

--- a/CertificateSigningRequest.podspec
+++ b/CertificateSigningRequest.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CertificateSigningRequest'
-  s.version          = '1.21'
+  s.version          = '1.22'
   s.summary          = 'Generate self-signed certificate signing requests (CSRs) on iOS, macOS, and macCatalyst.'
 
 # This description is used to generate tags and improve search results.

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,6 @@
 use_frameworks!
 platform :ios, '10.0'
+#platform :macos, '10.12'
 target 'CertificateSigningRequest_Example' do
   pod 'CertificateSigningRequest', :path => '../'
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CertificateSigningRequest (1.1)
+  - CertificateSigningRequest (1.21)
   - Nimble (7.3.4)
   - Quick (1.2.0)
 
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CertificateSigningRequest: 57b8bc63981428dc864260baf7495f27d52d644f
+  CertificateSigningRequest: 5edef17efccef3fb65cb621861b11e15521a6556
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
 
-PODFILE CHECKSUM: b0241bf7f0af64b7cf27906cb18896b8585e5993
+PODFILE CHECKSUM: 940f272539d8a7a33cbfec5a9de13dc17dd87fb8
 
 COCOAPODS: 1.9.1

--- a/Example/Pods/Local Podspecs/CertificateSigningRequest.podspec.json
+++ b/Example/Pods/Local Podspecs/CertificateSigningRequest.podspec.json
@@ -1,11 +1,11 @@
 {
   "name": "CertificateSigningRequest",
-  "version": "1.1",
+  "version": "1.21",
   "summary": "Generate self-signed certificate signing requests (CSRs) on iOS, macOS, and macCatalyst.",
   "description": "Enables your app to create self-signed CSRs directly on iOS devices. These CSRs can then be sent somewhere else and turned into certificates. The framework should also work on macCatalyst and macOS 10.12+, assuming the keys are created correctly (the test cases shows how to create keys using the iOS Keychain).",
   "homepage": "https://github.com/cbaker6/CertificateSigningRequest",
   "license": {
-    "type": "GNU",
+    "type": "GPLv2",
     "file": "LICENSE"
   },
   "authors": {
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/cbaker6/CertificateSigningRequest.git",
-    "tag": "1.1"
+    "tag": "1.21"
   },
   "platforms": {
     "ios": "9.3",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CertificateSigningRequest (1.1)
+  - CertificateSigningRequest (1.21)
   - Nimble (7.3.4)
   - Quick (1.2.0)
 
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CertificateSigningRequest: 57b8bc63981428dc864260baf7495f27d52d644f
+  CertificateSigningRequest: 5edef17efccef3fb65cb621861b11e15521a6556
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
 
-PODFILE CHECKSUM: b0241bf7f0af64b7cf27906cb18896b8585e5993
+PODFILE CHECKSUM: 940f272539d8a7a33cbfec5a9de13dc17dd87fb8
 
 COCOAPODS: 1.9.1

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -162,14 +162,14 @@
 /* Begin PBXFileReference section */
 		001FF222EA83335C3B8DDC5074A862C7 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
 		0094A06AD6DA53D8221A6A3894EBE456 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
-		01B00F5B76F8274E949CD00EC7199C0F /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		01B00F5B76F8274E949CD00EC7199C0F /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		02A4FE529CA8F0C68998F6B39C603467 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
 		033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		041DA3A9E60888E81EDC407BBDE87312 /* Nimble.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.debug.xcconfig; sourceTree = "<group>"; };
 		067C823065EF1CF3D619453B1CD12184 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
 		09D153164B47B1F8FD94B8C221767637 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
 		0B975F34A8D01181063AA6764228B61F /* CertificateSigningRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateSigningRequest.swift; path = CertificateSigningRequest/Classes/CertificateSigningRequest.swift; sourceTree = "<group>"; };
-		0D631E9908483F9525A6B3F36F16CC61 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D631E9908483F9525A6B3F36F16CC61 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F027235B72DB1D8068F1E1CA3567545 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
 		120569E985260497BE5BE039F8EA6DC1 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
 		1581729B7C5C85351FA7BD57E714B770 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
@@ -185,7 +185,7 @@
 		27C2E58D114AC181F6245906914BC378 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
 		2B1E5488251C2E363A401738AE0B015D /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
 		2C061463250766C9C05995AB8EE63E66 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		2D0C9C63CF609F1C6F37CD7FC4B6213D /* CertificateSigningRequest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CertificateSigningRequest.framework; path = CertificateSigningRequest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D0C9C63CF609F1C6F37CD7FC4B6213D /* CertificateSigningRequest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CertificateSigningRequest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3049ACFF04304D5A69F83457B0C750D8 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
 		31E0B323EBDB86405D253135E2BE94B5 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
 		3326DE447DD9522EC2436AFCFE32F3E7 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
@@ -224,14 +224,14 @@
 		5D6663844FD8AC4A8EFE4F009F43DE62 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
 		5FAA80FF2C63B9886F4440CCDB308DCB /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
 		5FC29EE7A1E0E658CD92E88FDE7C0CE5 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
-		60F46BF85BD973CECDDC1F59A5CACECF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		64F62F84305D8EAC8CB93AA03EB796A7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		60F46BF85BD973CECDDC1F59A5CACECF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		64F62F84305D8EAC8CB93AA03EB796A7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		68D5C468265817905E8BB3D3C5F607D6 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
 		6929BA2ACC06C155E591A32332B957F6 /* World+DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "World+DSL.h"; path = "Sources/QuickObjectiveC/DSL/World+DSL.h"; sourceTree = "<group>"; };
 		6A3949B2D0A443BF3E4F9702DD93325A /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
 		6BBFAE1C4DC8EB0BC8CEE93B7F258DE3 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
 		6DCC34278BA150666EB06169C1395D7C /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
-		6FBC5C80DCB6BBF0A8F8FF96DCC42A98 /* Pods_CertificateSigningRequest_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CertificateSigningRequest_Example.framework; path = "Pods-CertificateSigningRequest_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FBC5C80DCB6BBF0A8F8FF96DCC42A98 /* Pods_CertificateSigningRequest_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CertificateSigningRequest_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		701070485650A8DEFEDB605DDB008707 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
 		723E6B3079C0611ACCC3939031EDF200 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
 		72D12F832B12199869EC2812B758E446 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
@@ -252,7 +252,7 @@
 		976474E7D7496B4A4E5D33D4C8BF5A02 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
 		9A62D0C97CA01FB568E53F30CC5E60BB /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
 		9C531FF657A43F5FB7364CC7CC10C016 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9E1BDCAD60312625744438EFC3CFBFCB /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
 		9F074E9D624A6B99EC5D31DC5AF5A75B /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
 		A3B36151435E4AA5BC2A1EC1757F65FB /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
@@ -270,7 +270,7 @@
 		B7F3CFF98674E99C222B25815DA4296A /* Pods-CertificateSigningRequest_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CertificateSigningRequest_Example-Info.plist"; sourceTree = "<group>"; };
 		B8C5F64D03075691404D76199140494B /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
 		B93F204C6DD5BC20D1D410594A73E463 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
-		BAE263041362D074978BB3B577DF0A05 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAE263041362D074978BB3B577DF0A05 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBEC5CCE7BEDDE5F9088F1B6E292F746 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
 		BC32ADD4781C6B7B0998E52BA3E7EBA1 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
 		BD5D2196B1829A3EDBFB102126D560EF /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
@@ -294,13 +294,13 @@
 		D667B90B8BA83D1FBB1683F8C892AD88 /* Quick.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.release.xcconfig; sourceTree = "<group>"; };
 		D79523860B2DDD8B99587D381768193E /* Pods-CertificateSigningRequest_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CertificateSigningRequest_Example-umbrella.h"; sourceTree = "<group>"; };
 		DACBFEC6DD2FE515CFACB19CFF3AAE69 /* CertificateSigningRequestConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateSigningRequestConstants.swift; path = CertificateSigningRequest/Classes/CertificateSigningRequestConstants.swift; sourceTree = "<group>"; };
-		DB2E79C6D357AEDFEEDFA597FF8290F3 /* CertificateSigningRequest.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = CertificateSigningRequest.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		DB2E79C6D357AEDFEEDFA597FF8290F3 /* CertificateSigningRequest.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = CertificateSigningRequest.podspec; sourceTree = "<group>"; tabWidth = 2; };
 		DC011028EF971C9BF3E6EDCB74D8E2F7 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
 		DC38C51690D5AE2D21AD14140ED9CF11 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
 		DDB25ECAC21407AC062228EADC002E41 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
 		DE39882F09B9EA81FEC324D3FC163674 /* Pods-CertificateSigningRequest_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CertificateSigningRequest_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		DEC2154759D818DAEF28E291BB43A02A /* CertificateSigningRequest-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CertificateSigningRequest-umbrella.h"; sourceTree = "<group>"; };
-		DF3FF4FF8770B230F5A8218877A9839E /* Pods_CertificateSigningRequest_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CertificateSigningRequest_Tests.framework; path = "Pods-CertificateSigningRequest_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF3FF4FF8770B230F5A8218877A9839E /* Pods_CertificateSigningRequest_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CertificateSigningRequest_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0776DC4640A0D58A464997C9DD11243 /* Pods-CertificateSigningRequest_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CertificateSigningRequest_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		E3CC2893FCD5E6F763A904A6B79BD94E /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
 		E596FAB084FB38BAA6E6154A8948D07F /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
@@ -493,7 +493,6 @@
 				68D5C468265817905E8BB3D3C5F607D6 /* XCTestSuite+QuickTestSuiteBuilder.m */,
 				E6E0896F2F7ED20107992264FA24EF49 /* Support Files */,
 			);
-			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -571,7 +570,6 @@
 				F9A94CDCB33A101D63AA1765A1CFBDA3 /* XCTestObservationCenter+Register.m */,
 				278B699E0245FFFA3AD0FD68BF277F70 /* Support Files */,
 			);
-			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
@@ -1276,8 +1274,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/Example/Pods/Target Support Files/CertificateSigningRequest/CertificateSigningRequest-Info.plist
+++ b/Example/Pods/Target Support Files/CertificateSigningRequest/CertificateSigningRequest-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.0</string>
+  <string>1.21.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Pods-CertificateSigningRequest_Example/Pods-CertificateSigningRequest_Example-acknowledgements.plist
+++ b/Example/Pods/Target Support Files/Pods-CertificateSigningRequest_Example/Pods-CertificateSigningRequest_Example-acknowledgements.plist
@@ -690,7 +690,7 @@ Public License instead of this License.  But first, please read
 &lt;http://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
 </string>
 			<key>License</key>
-			<string>GNU</string>
+			<string>GPLv2</string>
 			<key>Title</key>
 			<string>CertificateSigningRequest</string>
 			<key>Type</key>

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -8,7 +8,7 @@ class TableOfContentsSpec: QuickSpec {
         
     override func spec() {
         
-        describe("these will fail") {
+        describe("test suite of different configurations") {
             beforeEach {
                 //Clear out App Keychain
                 var query: [String:AnyObject] = [String(kSecClass): kSecClassKey]
@@ -28,375 +28,412 @@ class TableOfContentsSpec: QuickSpec {
                 expect("time").toEventually( equal("done") )
             }*/
             
-            context("these will pass") {
-    
-                it("create CSR using Eliptic Curve key size 256") {
-                    let tagPrivate = "com.csr.private.ec"
-                    let tagPublic = "com.csr.public.ec"
-                    let keyAlgorithm = KeyAlgorithm.ec(signatureType: .sha256)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes.last!
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey, publicKey: publicKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey, publicKey: publicKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-
-                it("create CSR using RSA key size 2048 with sha512") {
-                    let tagPrivate = "com.csr.private.rsa"
-                    let tagPublic = "com.csr.public.rsa"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes.last!
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
+            it("create CSR using Eliptic Curve key size 256") {
+                let tagPrivate = "com.csr.private.ec"
+                let tagPublic = "com.csr.public.ec"
+                let keyAlgorithm = KeyAlgorithm.ec(signatureType: .sha256)
+                let sizeOfKey = keyAlgorithm.availableKeySizes.last!
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
                 }
                 
-                it("create CSR using RSA key size 2048 with sha256") {
-                    let tagPrivate = "com.csr.private.rsa256"
-                    let tagPublic = "com.csr.public.rsa256"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes.last!
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
                 }
                 
-                it("create CSR using RSA key size 2048 with sha1") {
-                    let tagPrivate = "com.csr.private.rsa1"
-                    let tagPublic = "com.csr.public.rsa1"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes.last!
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey, publicKey: publicKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
                 }
-                
-                it("create CSR using RSA key size 1024 with sha512") {
-                    let tagPrivate = "com.csr.private.rsa1024"
-                    let tagPublic = "com.csr.public.rsa1024"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey, publicKey: publicKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
                 }
-                
-                it("create CSR using RSA key size 1024 with sha256") {
-                    let tagPrivate = "com.csr.private.rsa1024sha256"
-                    let tagPublic = "com.csr.public.rsa1024sha256"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-                
-                it("create CSR using RSA key size 1024 with sha1") {
-                    let tagPrivate = "com.csr.private.rsa1024sha1"
-                    let tagPublic = "com.csr.public.rsa1024sha1"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-                
-                it("create CSR using RSA key size 512 with sha256") {
-                    let tagPrivate = "com.csr.private.rsa512"
-                    let tagPublic = "com.csr.public.rsa512"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[0]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-                
-                it("create CSR using RSA key size 512 with sha1") {
-                    let tagPrivate = "com.csr.private.rsa512sha1"
-                    let tagPublic = "com.csr.public.rsa512sha1"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[0]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-                
-                /*
-                it("will eventually pass") {
-                    var time = "passing"
-
-                    DispatchQueue.main.async {
-                        time = "done"
-                    }
-
-                    waitUntil { done in
-                        Thread.sleep(forTimeInterval: 0.5)
-                        expect(time) == "done"
-
-                        done()
-                    }
-                }*/
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
             }
+
+            it("create CSR using RSA key size 2048 with sha512") {
+                let tagPrivate = "com.csr.private.rsa"
+                let tagPublic = "com.csr.public.rsa"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
+                let sizeOfKey = keyAlgorithm.availableKeySizes.last!
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("create CSR using RSA key size 2048 with sha256") {
+                let tagPrivate = "com.csr.private.rsa256"
+                let tagPublic = "com.csr.public.rsa256"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
+                let sizeOfKey = keyAlgorithm.availableKeySizes.last!
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("create CSR using RSA key size 2048 with sha1") {
+                let tagPrivate = "com.csr.private.rsa1"
+                let tagPublic = "com.csr.public.rsa1"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
+                let sizeOfKey = keyAlgorithm.availableKeySizes.last!
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("create CSR using RSA key size 1024 with sha512") {
+                let tagPrivate = "com.csr.private.rsa1024"
+                let tagPublic = "com.csr.public.rsa1024"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
+                let sizeOfKey = keyAlgorithm.availableKeySizes[1]
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("create CSR using RSA key size 1024 with sha256") {
+                let tagPrivate = "com.csr.private.rsa1024sha256"
+                let tagPublic = "com.csr.public.rsa1024sha256"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
+                let sizeOfKey = keyAlgorithm.availableKeySizes[1]
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("create CSR using RSA key size 1024 with sha1") {
+                let tagPrivate = "com.csr.private.rsa1024sha1"
+                let tagPublic = "com.csr.public.rsa1024sha1"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
+                let sizeOfKey = keyAlgorithm.availableKeySizes[1]
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("fail to create CSR using RSA key size 512 with sha512") {
+                let tagPrivate = "com.csr.private.rsa512sha512"
+                let tagPublic = "com.csr.public.rsa512sha512"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
+                let sizeOfKey = keyAlgorithm.availableKeySizes[0]
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild2).to(beNil())
+                expect(csrBuild2).to(beNil())
+            }
+            
+            it("create CSR using RSA key size 512 with sha256") {
+                let tagPrivate = "com.csr.private.rsa512"
+                let tagPublic = "com.csr.public.rsa512"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
+                let sizeOfKey = keyAlgorithm.availableKeySizes[0]
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            it("create CSR using RSA key size 512 with sha1") {
+                let tagPrivate = "com.csr.private.rsa512sha1"
+                let tagPublic = "com.csr.public.rsa512sha1"
+                let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
+                let sizeOfKey = keyAlgorithm.availableKeySizes[0]
+                
+                let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                guard let privateKey = potentialPrivateKey,
+                    let publicKey = potentialPublicKey else{
+                        expect(potentialPrivateKey) != nil
+                        expect(potentialPublicKey) != nil
+                        return
+                }
+                
+                let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                guard let publicKeyBits = potentialPublicKeyBits,
+                    let _ = potentialPublicKeyBlockSize else{
+                        expect(potentialPublicKeyBits) != nil
+                        expect(potentialPublicKeyBlockSize) != nil
+                        return
+                }
+                
+                //Initiale CSR
+                let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                //Build the CSR
+                let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                if let csrRegular = csrBuild{
+                    print("CSR string no header and footer")
+                    print(csrRegular)
+                }
+                let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                if let csrWithHeaderFooter = csrBuild2{
+                    print("CSR string with header and footer")
+                    print(csrWithHeaderFooter)
+                }
+                expect(csrBuild?.count) > 0
+                expect(csrBuild2?.contains("BEGIN")) == true
+            }
+            
+            /*
+            it("will eventually pass") {
+                var time = "passing"
+
+                DispatchQueue.main.async {
+                    time = "done"
+                }
+
+                waitUntil { done in
+                    Thread.sleep(forTimeInterval: 0.5)
+                    expect(time) == "done"
+
+                    done()
+                }
+            }*/
+        
         }
     }
     

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -108,84 +108,6 @@ class TableOfContentsSpec: QuickSpec {
                     expect(csrBuild2?.contains("BEGIN")) == true
                 }
                 
-                it("create CSR using RSA key size 1024 with sha512") {
-                    let tagPrivate = "com.csr.private.rsa1024"
-                    let tagPublic = "com.csr.public.rsa1024"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-                
-                it("create CSR using RSA key size 512 with sha512") {
-                    let tagPrivate = "com.csr.private.rsa512"
-                    let tagPublic = "com.csr.public.rsa512"
-                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
-                    let sizeOfKey = keyAlgorithm.availableKeySizes[0]
-                    
-                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
-                    guard let privateKey = potentialPrivateKey,
-                        let publicKey = potentialPublicKey else{
-                            expect(potentialPrivateKey) != nil
-                            expect(potentialPublicKey) != nil
-                            return
-                    }
-                    
-                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
-                    guard let publicKeyBits = potentialPublicKeyBits,
-                        let _ = potentialPublicKeyBlockSize else{
-                            expect(potentialPublicKeyBits) != nil
-                            expect(potentialPublicKeyBlockSize) != nil
-                            return
-                    }
-                    
-                    //Initiale CSR
-                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
-                    //Build the CSR
-                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
-                    if let csrRegular = csrBuild{
-                        print("CSR string no header and footer")
-                        print(csrRegular)
-                    }
-                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
-                    if let csrWithHeaderFooter = csrBuild2{
-                        print("CSR string with header and footer")
-                        print(csrWithHeaderFooter)
-                    }
-                    expect(csrBuild?.count) > 0
-                    expect(csrBuild2?.contains("BEGIN")) == true
-                }
-                
                 it("create CSR using RSA key size 2048 with sha256") {
                     let tagPrivate = "com.csr.private.rsa256"
                     let tagPublic = "com.csr.public.rsa256"
@@ -230,6 +152,201 @@ class TableOfContentsSpec: QuickSpec {
                     let tagPublic = "com.csr.public.rsa1"
                     let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
                     let sizeOfKey = keyAlgorithm.availableKeySizes.last!
+                    
+                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                    guard let privateKey = potentialPrivateKey,
+                        let publicKey = potentialPublicKey else{
+                            expect(potentialPrivateKey) != nil
+                            expect(potentialPublicKey) != nil
+                            return
+                    }
+                    
+                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                    guard let publicKeyBits = potentialPublicKeyBits,
+                        let _ = potentialPublicKeyBlockSize else{
+                            expect(potentialPublicKeyBits) != nil
+                            expect(potentialPublicKeyBlockSize) != nil
+                            return
+                    }
+                    
+                    //Initiale CSR
+                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                    //Build the CSR
+                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                    if let csrRegular = csrBuild{
+                        print("CSR string no header and footer")
+                        print(csrRegular)
+                    }
+                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                    if let csrWithHeaderFooter = csrBuild2{
+                        print("CSR string with header and footer")
+                        print(csrWithHeaderFooter)
+                    }
+                    expect(csrBuild?.count) > 0
+                    expect(csrBuild2?.contains("BEGIN")) == true
+                }
+                
+                it("create CSR using RSA key size 1024 with sha512") {
+                    let tagPrivate = "com.csr.private.rsa1024"
+                    let tagPublic = "com.csr.public.rsa1024"
+                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha512)
+                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
+                    
+                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                    guard let privateKey = potentialPrivateKey,
+                        let publicKey = potentialPublicKey else{
+                            expect(potentialPrivateKey) != nil
+                            expect(potentialPublicKey) != nil
+                            return
+                    }
+                    
+                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                    guard let publicKeyBits = potentialPublicKeyBits,
+                        let _ = potentialPublicKeyBlockSize else{
+                            expect(potentialPublicKeyBits) != nil
+                            expect(potentialPublicKeyBlockSize) != nil
+                            return
+                    }
+                    
+                    //Initiale CSR
+                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                    //Build the CSR
+                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                    if let csrRegular = csrBuild{
+                        print("CSR string no header and footer")
+                        print(csrRegular)
+                    }
+                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                    if let csrWithHeaderFooter = csrBuild2{
+                        print("CSR string with header and footer")
+                        print(csrWithHeaderFooter)
+                    }
+                    expect(csrBuild?.count) > 0
+                    expect(csrBuild2?.contains("BEGIN")) == true
+                }
+                
+                it("create CSR using RSA key size 1024 with sha256") {
+                    let tagPrivate = "com.csr.private.rsa1024sha256"
+                    let tagPublic = "com.csr.public.rsa1024sha256"
+                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
+                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
+                    
+                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                    guard let privateKey = potentialPrivateKey,
+                        let publicKey = potentialPublicKey else{
+                            expect(potentialPrivateKey) != nil
+                            expect(potentialPublicKey) != nil
+                            return
+                    }
+                    
+                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                    guard let publicKeyBits = potentialPublicKeyBits,
+                        let _ = potentialPublicKeyBlockSize else{
+                            expect(potentialPublicKeyBits) != nil
+                            expect(potentialPublicKeyBlockSize) != nil
+                            return
+                    }
+                    
+                    //Initiale CSR
+                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                    //Build the CSR
+                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                    if let csrRegular = csrBuild{
+                        print("CSR string no header and footer")
+                        print(csrRegular)
+                    }
+                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                    if let csrWithHeaderFooter = csrBuild2{
+                        print("CSR string with header and footer")
+                        print(csrWithHeaderFooter)
+                    }
+                    expect(csrBuild?.count) > 0
+                    expect(csrBuild2?.contains("BEGIN")) == true
+                }
+                
+                it("create CSR using RSA key size 1024 with sha1") {
+                    let tagPrivate = "com.csr.private.rsa1024sha1"
+                    let tagPublic = "com.csr.public.rsa1024sha1"
+                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
+                    let sizeOfKey = keyAlgorithm.availableKeySizes[1]
+                    
+                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                    guard let privateKey = potentialPrivateKey,
+                        let publicKey = potentialPublicKey else{
+                            expect(potentialPrivateKey) != nil
+                            expect(potentialPublicKey) != nil
+                            return
+                    }
+                    
+                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                    guard let publicKeyBits = potentialPublicKeyBits,
+                        let _ = potentialPublicKeyBlockSize else{
+                            expect(potentialPublicKeyBits) != nil
+                            expect(potentialPublicKeyBlockSize) != nil
+                            return
+                    }
+                    
+                    //Initiale CSR
+                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                    //Build the CSR
+                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                    if let csrRegular = csrBuild{
+                        print("CSR string no header and footer")
+                        print(csrRegular)
+                    }
+                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                    if let csrWithHeaderFooter = csrBuild2{
+                        print("CSR string with header and footer")
+                        print(csrWithHeaderFooter)
+                    }
+                    expect(csrBuild?.count) > 0
+                    expect(csrBuild2?.contains("BEGIN")) == true
+                }
+                
+                it("create CSR using RSA key size 512 with sha256") {
+                    let tagPrivate = "com.csr.private.rsa512"
+                    let tagPublic = "com.csr.public.rsa512"
+                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha256)
+                    let sizeOfKey = keyAlgorithm.availableKeySizes[0]
+                    
+                    let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
+                    guard let privateKey = potentialPrivateKey,
+                        let publicKey = potentialPublicKey else{
+                            expect(potentialPrivateKey) != nil
+                            expect(potentialPublicKey) != nil
+                            return
+                    }
+                    
+                    let (potentialPublicKeyBits, potentialPublicKeyBlockSize) = self.getPublicKeyBits(keyAlgorithm, publicKey: publicKey, tagPublic: tagPublic)
+                    guard let publicKeyBits = potentialPublicKeyBits,
+                        let _ = potentialPublicKeyBlockSize else{
+                            expect(potentialPublicKeyBits) != nil
+                            expect(potentialPublicKeyBlockSize) != nil
+                            return
+                    }
+                    
+                    //Initiale CSR
+                    let csr = CertificateSigningRequest(commonName: "CertificateSigningRequest Test", organizationName: "Test", organizationUnitName: "Test", countryName: "US", stateOrProvinceName: "KY", localityName: "Test", keyAlgorithm: keyAlgorithm)
+                    //Build the CSR
+                    let csrBuild = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)
+                    if let csrRegular = csrBuild{
+                        print("CSR string no header and footer")
+                        print(csrRegular)
+                    }
+                    let csrBuild2 = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+                    if let csrWithHeaderFooter = csrBuild2{
+                        print("CSR string with header and footer")
+                        print(csrWithHeaderFooter)
+                    }
+                    expect(csrBuild?.count) > 0
+                    expect(csrBuild2?.contains("BEGIN")) == true
+                }
+                
+                it("create CSR using RSA key size 512 with sha1") {
+                    let tagPrivate = "com.csr.private.rsa512sha1"
+                    let tagPublic = "com.csr.public.rsa512sha1"
+                    let keyAlgorithm = KeyAlgorithm.rsa(signatureType: .sha1)
+                    let sizeOfKey = keyAlgorithm.availableKeySizes[0]
                     
                     let (potentialPrivateKey,potentialPublicKey) = self.generateKeysAndStoreInKeychain(keyAlgorithm, keySize: sizeOfKey, tagPrivate: tagPrivate, tagPublic: tagPublic)
                     guard let privateKey = potentialPrivateKey,

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ let csr = CertificateSigningRequest(commonName: String?, organizationName:String
  //Or if you want `CertificateSigningRequest` to verify the signature after building, pass in your publicKey to the same method:
  let builtCSR = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey, publicKey: publicKey)
  ``` 
--- Two other methods are available depending on your needs.
---- To get CSR without header and footer info use: `let builtCSR = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)`.
---- To get CSR as Data use: `let builtCSR = csr.build(publicKeyBits, privateKey: privateKey)`.
+- Two other methods are available depending on your needs.
+- To get CSR without header and footer info use: `let builtCSR = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)`.
+- To get CSR as Data use: `let builtCSR = csr.build(publicKeyBits, privateKey: privateKey)`.
 
 Note:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports RSA (key size: 512, 1024, 2048) and EC inside/outside of secure enclave
 
 To use, follow the following steps:
 
-1. Generate your publicKey/privateKey pair. This can be done using Keychain in iOS. An example can be found in the `generateKeysAndStoreInKeychain` function in the [testfile](https://github.com/cbaker6/CertificateSigningRequest/blob/91aab984c94c6fb2b97afa87494ac2281381cbdc/Example/Tests/Tests.swift#L286).
+1. Generate your publicKey/privateKey pair. This can be done using Keychain in iOS. An example can be found in the `generateKeysAndStoreInKeychain` function in the [testfile](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L403).
 2.  Get your publicKey in bits by querying it from the iOS keychain using `String(kSecReturnData): kCFBooleanTrue` in your query. For example:
 
 ```swift
@@ -29,7 +29,7 @@ guard let publicKeyBits = tempPublicKeyBits as? Data else {
     return
 }
 ```
-3. Initiatlize the `CertificateSigningRequest` using `KeyAlgorithm.ec` or `KeyAlgorithm.rsa` (an example of how to do can be found in the [test](https://github.com/cbaker6/CertificateSigningRequest/blob/460e288156285e910af3181e0298a3aadd7f53a9/Example/Tests/Tests.swift#L19) file: 
+3. Initiatlize the `CertificateSigningRequest` using `KeyAlgorithm.ec` or `KeyAlgorithm.rsa` (an example of how to do can be found in the [test](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L36) file: 
 ```swift 
 let algorithm = KeyAlgorithm.ec(signatureType: .sha256)
 let csr = CertificateSigningRequest()
@@ -49,7 +49,7 @@ let csr = CertificateSigningRequest(commonName: String?, organizationName:String
 
 Note:
 
-You can test if your CSRs are correct by running the [test file](https://github.com/cbaker6/CertificateSigningRequest/blob/830b97fa1435024209577917628a58aa53323990/Example/Tests/Tests.swift#L68). The output of the CSR will print in the console window. You can test if the CSR was created correctly by pasting it here: https://redkestrel.co.uk/products/decoder/ or by using openssl.
+You can test if your CSRs are correct by running the [test file](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L68). The output of the CSR will print in the console window. You can test if the CSR was created correctly by pasting it here: https://redkestrel.co.uk/products/decoder/ or by using openssl.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports RSA (key size: 512, 1024, 2048) and EC inside/outside of secure enclave
 
 To use, follow the following steps:
 
-1. Generate your publicKey/privateKey pair. This can be done using Keychain in iOS. An example can be found in the `generateKeysAndStoreInKeychain` function in the [testfile](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L403).
+1. Generate your publicKey/privateKey pair. This can be done using Keychain in iOS. An example can be found in the `generateKeysAndStoreInKeychain` function in the [testfile](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L440).
 2.  Get your publicKey in bits by querying it from the iOS keychain using `String(kSecReturnData): kCFBooleanTrue` in your query. For example:
 
 ```swift
@@ -29,7 +29,7 @@ guard let publicKeyBits = tempPublicKeyBits as? Data else {
     return
 }
 ```
-3. Initiatlize the `CertificateSigningRequest` using `KeyAlgorithm.ec` or `KeyAlgorithm.rsa` (an example of how to do can be found in the [test](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L36) file: 
+3. Initiatlize the `CertificateSigningRequest` using `KeyAlgorithm.ec` or `KeyAlgorithm.rsa` (an example of how to do can be found in the [test](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L34) file: 
 ```swift 
 let algorithm = KeyAlgorithm.ec(signatureType: .sha256)
 let csr = CertificateSigningRequest()
@@ -49,7 +49,7 @@ let csr = CertificateSigningRequest(commonName: String?, organizationName:String
 
 Note:
 
-You can test if your CSRs are correct by running the [test file](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L68). The output of the CSR will print in the console window. You can test if the CSR was created correctly by pasting it here: https://redkestrel.co.uk/products/decoder/ or by using openssl.
+You can test if your CSRs are correct by running and setting a break point the [test file](https://github.com/cbaker6/CertificateSigningRequest/blob/master/Example/Tests/Tests.swift#L66). You can also let all test run and test the different CSR's. The output of the CSR will print in the console window. You can output the CSR's and your own app by printing to the console and check if they are created correctly by pasting them here: https://redkestrel.co.uk/products/decoder/ or by using openssl.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,18 @@
 # CertificateSigningRequest
-![Swift Version 4.2](https://img.shields.io/badge/Swift-v5.0-yellow.svg)
+![Swift Version 5.0](https://img.shields.io/badge/Swift-v5.0-yellow.svg)
 [![CI Status](https://img.shields.io/travis/cbaker6/CertificateSigningRequest.svg?style=flat)](https://travis-ci.org/cbaker6/CertificateSigningRequest)
 [![Version](https://img.shields.io/cocoapods/v/CertificateSigningRequest.svg?style=flat)](https://cocoapods.org/pods/CertificateSigningRequest)
 [![License](https://img.shields.io/cocoapods/l/CertificateSigningRequest.svg?style=flat)](https://cocoapods.org/pods/CertificateSigningRequest)
 [![Platform](https://img.shields.io/cocoapods/p/CertificateSigningRequest.svg?style=flat)](https://cocoapods.org/pods/CertificateSigningRequest)
 
-Generate a certificate signing request (CSR) in iOS using Swift
+Generate a certificate signing request (CSR) in iOS/macOS using Swift.
 
-This is a port of ios-csr by Ales Teska (https://github.com/ateska/ios-csr) from Objective-C to Swift 5.0 (a Swift 3.2 version is available on the "3.2" branch).
-Additions have been made to support RSA and EC (iOS only supports 256 bit keys for now) allow SHA256 and SHA512. Also, this is setup to be added as a framework to your project.
+Supports RSA (key size: 512, 1024, 2048) and EC inside/outside of secure enclave (iOS only supports 256 bit keys for now), SHA1, SHA256, and SHA512. 
 
-To use, initiatlize the class using one of the following (an example of how to do can be found in the [test](https://github.com/cbaker6/CertificateSigningRequest/blob/460e288156285e910af3181e0298a3aadd7f53a9/Example/Tests/Tests.swift#L19) file: 
-- `let csr = CertificateSigningRequest()`
-- `let csr = CertificateSigningRequest(keyAlgorithm: KeyAlgorithm)`
-- `let csr = CertificateSigningRequest(commonName: String?, organizationName:String?, organizationUnitName:String?, countryName:String?, stateOrProvinceName:String?, localityName:String?, keyAlgorithm: KeyAlgorithm)`
+To use, follow the following steps:
 
-Then simply build your CSR using your publicKey(bits) and privateKey using, `let builtCSR = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)`.
-
-Two other methods are available depending on your needs.
-
-- To get CSR without header and footer info use: `let builtCSR = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)`.
-- To get CSR as Data use: `let builtCSR = csr.build(publicKeyBits, privateKey: privateKey)`.
-
-Note1: To use out of the box, build the project, look under frameworks, and drag "CertificateSigningRequest.framework" into your project. You will need to do this in two places:
-
-- In your project Targets, click on "General"
-- Place "CertificateSigningRequest.framework" in "Embedded Binaries" and it should automatically appear in "Linked Frameworks and Libraries"
-- Then, simply place "import CertificateSigningRequest" at the top of any file that needs the framework.
-
-Note2: You can get your publicKey in bit by querying it from the iOS keychain using `String(kSecReturnData): kCFBooleanTrue` in your query. For example:
+1. Generate your publicKey/privateKey pair. This can be done using Keychain in iOS. An example can be found in the `generateKeysAndStoreInKeychain` function in the [testfile](https://github.com/cbaker6/CertificateSigningRequest/blob/91aab984c94c6fb2b97afa87494ac2281381cbdc/Example/Tests/Tests.swift#L286).
+2.  Get your publicKey in bits by querying it from the iOS keychain using `String(kSecReturnData): kCFBooleanTrue` in your query. For example:
 
 ```swift
 let keyBlockSize = SecKeyGetBlockSize(publicKey)
@@ -41,14 +25,31 @@ let query: [String: AnyObject] = [
 ]
 var tempPublicKeyBits:AnyObject?
 var _ = SecItemCopyMatching(query as CFDictionary, &tempPublicKeyBits)
-guard let keyBits = tempPublicKeyBits as? Data else {
-    return (nil,nil)
+guard let publicKeyBits = tempPublicKeyBits as? Data else {
+    return
 }
 ```
+3. Initiatlize the `CertificateSigningRequest` using `KeyAlgorithm.ec` or `KeyAlgorithm.rsa` (an example of how to do can be found in the [test](https://github.com/cbaker6/CertificateSigningRequest/blob/460e288156285e910af3181e0298a3aadd7f53a9/Example/Tests/Tests.swift#L19) file: 
+```swift 
+let algorithm = KeyAlgorithm.ec(signatureType: .sha256)
+let csr = CertificateSigningRequest()
+let csr = CertificateSigningRequest(keyAlgorithm: algorithm)
+let csr = CertificateSigningRequest(commonName: String?, organizationName:String?, organizationUnitName:String?, countryName:String?, stateOrProvinceName:String?, localityName:String?, keyAlgorithm: algorithm)
+```
 
-You can test if your CSRs are correct by running the [test file](https://github.com/cbaker6/CertificateSigningRequest/blob/830b97fa1435024209577917628a58aa53323990/Example/Tests/Tests.swift#L68). The output of the CSR will print in the console window. You can test if the CSR was created correctly here: https://redkestrel.co.uk/products/decoder/
+4. Then simply build your CSR using your publicKey(bits) and privateKey using:
+ ```swift 
+ let builtCSR = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)
+ //Or if you want `CertificateSigningRequest` to verify the signature after building, pass in your publicKey to the same method:
+ let builtCSR = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey, publicKey: publicKey)
+ ``` 
+-- Two other methods are available depending on your needs.
+--- To get CSR without header and footer info use: `let builtCSR = csr.buildAndEncodeDataAsString(publicKeyBits, privateKey: privateKey)`.
+--- To get CSR as Data use: `let builtCSR = csr.build(publicKeyBits, privateKey: privateKey)`.
 
-~~Note3: If you use this as a framework, you will need to go to Targets->APPNAME->General and add "CertificateSigningRequest.framework" to Embedded Binaries". You may need to add "CommonCrypto.framework" as well. If you just use want to use CertificateSigningRequest.swift you will need to import CommonCrypto into your project. To do this follow the directions here: http://stackoverflow.com/questions/25248598/importing-commoncrypto-in-a-swift-framework?answertab=votes#tab-top~~
+Note:
+
+You can test if your CSRs are correct by running the [test file](https://github.com/cbaker6/CertificateSigningRequest/blob/830b97fa1435024209577917628a58aa53323990/Example/Tests/Tests.swift#L68). The output of the CSR will print in the console window. You can test if the CSR was created correctly by pasting it here: https://redkestrel.co.uk/products/decoder/ or by using openssl.
 
 ## Example
 
@@ -69,6 +70,8 @@ vtFAmaxL8+rK+Hr55f0PLZQ5PcM=
 You can test if the CSR was created correctly here: [https://redkestrel.co.uk/products/decoder/](https://redkestrel.co.uk/products/decoder/)
 
 ## Requirements
+- iOS 9+
+- mac OS 10.12+
 
 ## Installation
 
@@ -79,10 +82,14 @@ it, simply add the following line to your Podfile:
 pod 'CertificateSigningRequest'
 ```
 
+If you would like to use as a framework, clone and build the project, look under frameworks, and drag "CertificateSigningRequest.framework" into "Frameworks" section of your project, "check copy if needed".
+
+- In your project Targets, click on "General", make sure "CertificateSigningRequest.framework" shows up under "Embedded Binaries" and it should automatically appear in "Linked Frameworks and Libraries"
+- Then, simply place `import CertificateSigningRequest` at the top of any file that needs the framework.
+
 ## Author
 
 cbaker6, coreyearleon@icloud.com
 
 ## License
-
-CertificateSigningRequest is available under the MIT license. See the LICENSE file for more info.
+Components of CertificateSigningRequest was originally in [ios-csr](https://github.com/ateska/ios-csr) by Ales Teska written in Objective-C and ported by the author of CertificateSigningRequest to Swift. Therefore CertificateSigningRequest has the same GPLv2 license. See the LICENSE file for more info.


### PR DESCRIPTION
In some corner cases, trying to create a CSR with an RSA 512bit key and SHA512 hash, an unfinished cert would be returned instead of returning nil.

Updated the readme to make using the framework more clear.